### PR TITLE
Revert "Move CRB to avoid clash with device tree buffer"

### DIFF
--- a/plat/qemu/qemu_sbsa/fdts/qemu_sbsa_spmc_sp_manifest.dts
+++ b/plat/qemu/qemu_sbsa/fdts/qemu_sbsa_spmc_sp_manifest.dts
@@ -108,7 +108,7 @@
 
   memory@8 {
     device_type = "device-memory"; /* Internal CRB */
-    reg = <0x00000100 0x00200000 0x0 0x00010000>;
+    reg = <0x00000100 0x00010000 0x0 0x00010000>;
   };
 
   memory@9 {


### PR DESCRIPTION
Reverts kuqin12/arm-trusted-firmware#2