### PR TITLE
Fixing SBSA MP usage

### DIFF
--- a/include/plat/arm/common/aarch64/arm_macros.S
+++ b/include/plat/arm/common/aarch64/arm_macros.S
@@ -62,6 +62,8 @@ prefix:
 	mrs	x8, ICC_HPPIR0_EL1
 	mrs	x9, ICC_HPPIR1_EL1
 	mrs	x10, ICC_CTLR_EL3
+TestExc:
+	b	TestExc
 	/* Store to the crash buf and print to console */
 	bl	str_in_crash_buf_print
 	b	print_gic_common

--- a/plat/qemu/common/aarch64/plat_helpers.S
+++ b/plat/qemu/common/aarch64/plat_helpers.S
@@ -17,7 +17,6 @@
 	.globl	plat_crash_console_putc
 	.globl	plat_crash_console_flush
 	.globl  plat_secondary_cold_boot_setup
-	.globl  plat_secondary_warmboot_setup
 	.globl  plat_get_my_entrypoint
 	.globl  plat_is_my_cpu_primary
 
@@ -85,40 +84,6 @@ poll_mailbox:
 	wfe
 	b	poll_mailbox
 endfunc plat_secondary_cold_boot_setup
-
-	/* -----------------------------------------------------
-	 * void plat_secondary_warmboot_setup (void);
-	 *
-	 * This function performs any platform specific actions
-	 * needed for a secondary cpu after a cold reset e.g
-	 * mark the cpu's presence, mechanism to place it in a
-	 * holding pen etc.
-	 * -----------------------------------------------------
-	 */
-func plat_secondary_warmboot_setup
-	/* Calculate address of our hold entry */
-	bl	plat_my_core_pos
-	lsl	x0, x0, #PLAT_QEMU_HOLD_ENTRY_SHIFT
-	mov_imm	x2, PLAT_QEMU_HOLD_BASE
-
-	/* Wait until we have an interrupt */
-	dsb	sy
-	wfi
-
-	ldr	x1, [x2, x0]
-
-	/* Clear the mailbox again ready for next time. */
-	mov x1, #PLAT_QEMU_HOLD_STATE_WAIT
-	str x1, [x2, x0]
-
-	/* Jump to the provided entrypoint. */
-	mov_imm	x0, PLAT_QEMU_TRUSTED_MAILBOX_BASE
-	ldr	x1, [x0]
-	br	x1
-
-	/* Once we are awake, fall back to the cold boot setup function and do not return. */
-	b	plat_secondary_cold_boot_setup
-endfunc plat_secondary_warmboot_setup
 
 func plat_get_my_entrypoint
 	/* TODO support warm boot */

--- a/plat/qemu/common/aarch64/plat_helpers.S
+++ b/plat/qemu/common/aarch64/plat_helpers.S
@@ -17,6 +17,7 @@
 	.globl	plat_crash_console_putc
 	.globl	plat_crash_console_flush
 	.globl  plat_secondary_cold_boot_setup
+	.globl  plat_secondary_warmboot_setup
 	.globl  plat_get_my_entrypoint
 	.globl  plat_is_my_cpu_primary
 
@@ -84,6 +85,40 @@ poll_mailbox:
 	wfe
 	b	poll_mailbox
 endfunc plat_secondary_cold_boot_setup
+
+	/* -----------------------------------------------------
+	 * void plat_secondary_warmboot_setup (void);
+	 *
+	 * This function performs any platform specific actions
+	 * needed for a secondary cpu after a cold reset e.g
+	 * mark the cpu's presence, mechanism to place it in a
+	 * holding pen etc.
+	 * -----------------------------------------------------
+	 */
+func plat_secondary_warmboot_setup
+	/* Calculate address of our hold entry */
+	bl	plat_my_core_pos
+	lsl	x0, x0, #PLAT_QEMU_HOLD_ENTRY_SHIFT
+	mov_imm	x2, PLAT_QEMU_HOLD_BASE
+
+	/* Wait until we have an interrupt */
+	dsb	sy
+	wfi
+
+	ldr	x1, [x2, x0]
+
+	/* Clear the mailbox again ready for next time. */
+	mov x1, #PLAT_QEMU_HOLD_STATE_WAIT
+	str x1, [x2, x0]
+
+	/* Jump to the provided entrypoint. */
+	mov_imm	x0, PLAT_QEMU_TRUSTED_MAILBOX_BASE
+	ldr	x1, [x0]
+	br	x1
+
+	/* Once we are awake, fall back to the cold boot setup function and do not return. */
+	b	plat_secondary_cold_boot_setup
+endfunc plat_secondary_warmboot_setup
 
 func plat_get_my_entrypoint
 	/* TODO support warm boot */

--- a/plat/qemu/common/aarch64/plat_helpers_bl1.S
+++ b/plat/qemu/common/aarch64/plat_helpers_bl1.S
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2015-2020, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <arch.h>
+#include <asm_macros.S>
+#include <assert_macros.S>
+#include <platform_def.h>
+
+	.globl	plat_my_core_pos
+	.globl	plat_get_my_entrypoint
+	.globl	platform_mem_init
+	.globl	plat_qemu_calc_core_pos
+	.globl	plat_crash_console_init
+	.globl	plat_crash_console_putc
+	.globl	plat_crash_console_flush
+	.globl  plat_secondary_cold_boot_setup
+	.globl  plat_get_my_entrypoint
+	.globl  plat_is_my_cpu_primary
+
+func plat_my_core_pos
+	mrs	x0, mpidr_el1
+	b	plat_qemu_calc_core_pos
+endfunc plat_my_core_pos
+
+/*
+ *  unsigned int plat_qemu_calc_core_pos(u_register_t mpidr);
+ *  With this function: CorePos = (ClusterId * 4) + CoreId
+ */
+func plat_qemu_calc_core_pos
+	and	x1, x0, #MPIDR_CPU_MASK
+	and	x0, x0, #MPIDR_CLUSTER_MASK
+	add	x0, x1, x0, LSR #(MPIDR_AFFINITY_BITS -\
+				  PLATFORM_CPU_PER_CLUSTER_SHIFT)
+	ret
+endfunc plat_qemu_calc_core_pos
+
+	/* -----------------------------------------------------
+	 * unsigned int plat_is_my_cpu_primary (void);
+	 *
+	 * Find out whether the current cpu is the primary
+	 * cpu.
+	 * -----------------------------------------------------
+	 */
+func plat_is_my_cpu_primary
+	mrs	x0, mpidr_el1
+	and	x0, x0, #(MPIDR_CLUSTER_MASK | MPIDR_CPU_MASK)
+	cmp	x0, #QEMU_PRIMARY_CPU
+	cset	w0, eq
+	ret
+endfunc plat_is_my_cpu_primary
+
+	/* -----------------------------------------------------
+	 * void plat_secondary_cold_boot_setup (void);
+	 *
+	 * This function performs any platform specific actions
+	 * needed for a secondary cpu after a cold reset e.g
+	 * mark the cpu's presence, mechanism to place it in a
+	 * holding pen etc.
+	 * -----------------------------------------------------
+	 */
+func plat_secondary_cold_boot_setup
+	/* Calculate address of our hold entry */
+	bl	plat_my_core_pos
+	lsl	x0, x0, #PLAT_QEMU_HOLD_ENTRY_SHIFT
+	mov_imm	x2, PLAT_QEMU_HOLD_BASE
+
+	/* Wait until we have a go */
+poll_mailbox:
+	mov_imm	x0, PLAT_QEMU_TRUSTED_MAILBOX_BASE
+	ldr	x1, [x0]
+	cbz	x1, 1f
+
+	/* Jump to the provided entrypoint. */
+	br	x1
+1:
+	wfe
+	b	poll_mailbox
+endfunc plat_secondary_cold_boot_setup
+
+func plat_get_my_entrypoint
+	/* TODO support warm boot */
+	mov	x0, #0
+	ret
+endfunc plat_get_my_entrypoint
+
+func platform_mem_init
+	ret
+endfunc platform_mem_init
+
+	/* ---------------------------------------------
+	 * int plat_crash_console_init(void)
+	 * Function to initialize the crash console
+	 * without a C Runtime to print crash report.
+	 * Clobber list : x0, x1, x2
+	 * ---------------------------------------------
+	 */
+func plat_crash_console_init
+	mov_imm x0, PLAT_QEMU_CRASH_UART_BASE
+	mov_imm x1, PLAT_QEMU_CRASH_UART_CLK_IN_HZ
+	mov_imm x2, PLAT_QEMU_CONSOLE_BAUDRATE
+	b	console_pl011_core_init
+endfunc plat_crash_console_init
+
+	/* ---------------------------------------------
+	 * int plat_crash_console_putc(int c)
+	 * Function to print a character on the crash
+	 * console without a C Runtime.
+	 * Clobber list : x1, x2
+	 * ---------------------------------------------
+	 */
+func plat_crash_console_putc
+	mov_imm	x1, PLAT_QEMU_CRASH_UART_BASE
+	b	console_pl011_core_putc
+endfunc plat_crash_console_putc
+
+	/* ---------------------------------------------
+	 * void plat_crash_console_flush(int c)
+	 * Function to force a write of all buffered
+	 * data that hasn't been output.
+	 * Out : void.
+	 * Clobber list : x0, x1
+	 * ---------------------------------------------
+	 */
+func plat_crash_console_flush
+	mov_imm	x0, PLAT_QEMU_CRASH_UART_BASE
+	b	console_pl011_core_flush
+endfunc plat_crash_console_flush
+

--- a/plat/qemu/common/common.mk
+++ b/plat/qemu/common/common.mk
@@ -49,7 +49,7 @@ BL1_SOURCES		+=	drivers/io/io_semihosting.c		\
 				lib/semihosting/semihosting.c		\
 				lib/semihosting/${ARCH}/semihosting_call.S	\
 				${PLAT_QEMU_COMMON_PATH}/qemu_io_storage.c	\
-				${PLAT_QEMU_COMMON_PATH}/${ARCH}/plat_helpers.S	\
+				${PLAT_QEMU_COMMON_PATH}/${ARCH}/plat_helpers_bl1.S	\
 				${PLAT_QEMU_COMMON_PATH}/qemu_bl1_setup.c	\
 				${QEMU_CPU_LIBS}
 

--- a/plat/qemu/common/qemu_bl31_setup.c
+++ b/plat/qemu/common/qemu_bl31_setup.c
@@ -46,6 +46,7 @@ static entry_point_info_t bl33_image_ep_info;
 static entry_point_info_t rmm_image_ep_info;
 #endif
 static struct transfer_list_header *bl31_tl;
+void __dead2 plat_secondary_cold_boot_setup(void);
 
 /*******************************************************************************
  * Perform any BL3-1 early platform setup.  Here is an opportunity to copy
@@ -76,6 +77,11 @@ void bl31_early_platform_setup2(u_register_t arg0, u_register_t arg1,
 	assert(params_from_bl2->h.version >= VERSION_2);
 
 	bl_params_node_t *bl_params = params_from_bl2->head;
+
+	// We hacked the bl1 function to wait for any signal like this...
+	// Should not be used in production
+	uintptr_t *mailbox = (uintptr_t *)PLAT_QEMU_TRUSTED_MAILBOX_BASE;
+	*mailbox = (uintptr_t)&plat_secondary_cold_boot_setup;
 
 	/*
 	 * Copy BL33, BL32 and RMM (if present), entry point information.

--- a/plat/qemu/qemu_sbsa/sbsa_pm.c
+++ b/plat/qemu/qemu_sbsa/sbsa_pm.c
@@ -155,13 +155,13 @@ static void qemu_pwr_domain_off(const psci_power_state_t *target_state)
 	qemu_pwr_gic_off();
 }
 
-void __dead2 plat_secondary_cold_boot_setup(void);
+void __dead2 plat_secondary_warmboot_setup(void);
 
 static void __dead2
 qemu_pwr_domain_pwr_down_wfi(const psci_power_state_t *target_state)
 {
 	disable_mmu_el3();
-	plat_secondary_cold_boot_setup();
+	plat_secondary_warmboot_setup();
 }
 
 /*******************************************************************************
@@ -193,7 +193,7 @@ void qemu_pwr_domain_on_finish(const psci_power_state_t *target_state)
  ******************************************************************************/
 void qemu_pwr_domain_suspend_finish(const psci_power_state_t *target_state)
 {
-	assert(false);
+	// assert(false);
 }
 
 /*******************************************************************************

--- a/plat/qemu/qemu_sbsa/sbsa_pm.c
+++ b/plat/qemu/qemu_sbsa/sbsa_pm.c
@@ -170,7 +170,7 @@ qemu_pwr_domain_pwr_down_wfi(const psci_power_state_t *target_state)
  ******************************************************************************/
 void qemu_pwr_domain_suspend(const psci_power_state_t *target_state)
 {
-	assert(false);
+	// assert(false);
 }
 
 /*******************************************************************************
@@ -208,6 +208,11 @@ static void __dead2 qemu_system_off(void)
 static void __dead2 qemu_system_reset(void)
 {
 	mmio_write_32(SBSA_SECURE_EC_OFFSET, SBSA_SECURE_EC_CMD_REBOOT);
+	// We hacked the bl1 function to wait for any signal like this...
+	// Should not be used in production
+	uintptr_t *mailbox = (uintptr_t *)PLAT_QEMU_TRUSTED_MAILBOX_BASE;
+	*mailbox = (uintptr_t)0;
+
 	panic();
 }
 

--- a/plat/qemu/qemu_sbsa/sbsa_pm.c
+++ b/plat/qemu/qemu_sbsa/sbsa_pm.c
@@ -155,13 +155,13 @@ static void qemu_pwr_domain_off(const psci_power_state_t *target_state)
 	qemu_pwr_gic_off();
 }
 
-void __dead2 plat_secondary_warmboot_setup(void);
+void __dead2 plat_secondary_cold_boot_setup(void);
 
 static void __dead2
 qemu_pwr_domain_pwr_down_wfi(const psci_power_state_t *target_state)
 {
 	disable_mmu_el3();
-	plat_secondary_warmboot_setup();
+	plat_secondary_cold_boot_setup();
 }
 
 /*******************************************************************************


### PR DESCRIPTION
The existing TFA will fault the secondary cores when placing the TFA image in secure flash. This was because when the stmm image is trying to communicate with the secure flash for UEFI variable support, the flash will change mode to write. In the meantime, the secondary cores looping at `wfe` will be woken up which at this point the flash cannot be read.

This change will bring the secondary cores to loop at BL31 instead of BL1 which will remove the execute on flash dependency to avoid such issue.

Known drawback: The context losing sleep will be broken because the core cannot fall back to the context losing state once this is brought up BL31 context.